### PR TITLE
Recude phase increment by a factor of 5.

### DIFF
--- a/include/l3xz_gait_ctrl/gait/state/Walking.h
+++ b/include/l3xz_gait_ctrl/gait/state/Walking.h
@@ -53,7 +53,7 @@ public:
 
 private:
   static const std::vector<KDL::Vector> FOOT_TRAJECTORY;
-  static constexpr float PHASE_INCREMENT_ABS = 0.005;
+  static constexpr float PHASE_INCREMENT_ABS = 0.001;
 
   const float _phase_increment;
   float _phase = 0;   ///< (-1,+1)


### PR DESCRIPTION
This becomes necessary because the control loop rate has been reduced from 20 Hz (50 ms) to 10 ms. Instead of the gait running 5 times as fast we'd rather decrease the phase increment.

CC @pavel-kirienko.